### PR TITLE
Print Status as well if api code fails

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -106,7 +106,7 @@ async function createPrComment(markdown, updateCommentIfOneExists, commentIdenti
         core.info(`PR comment was updated.  ID: ${response.data.id}.`);
       })
       .catch(error => {
-        core.setFailed(`An error occurred trying to update the PR comment: ${error.message}`);
+        core.setFailed(`An error occurred trying to update the PR comment: ${error.message}. Status: {error.status}`);
       });
   } else {
     core.info(`Creating a new PR comment...`);
@@ -168,7 +168,7 @@ async function createStatusCheck(reportName, checkName, markdown, conclusion) {
       statusCheckId = response.data.id;
     })
     .catch(error => {
-      core.setFailed(`An error occurred trying to create the status check: ${error.message}`);
+      core.setFailed(`An error occurred trying to create the status check: ${error.message}. Status: {error.status}`);
     });
   return statusCheckId;
 }


### PR DESCRIPTION
# Summary of PR changes

The error status helps us to troubleshoot better. Currently the error message only shows the message which sometimes can be generic. For example:

Error: An error occurred trying to create the status check: Invalid request.

## PR Requirements
- [ ] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [ ] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
