### PR TITLE
DEVO-1052 - update node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ jobs:
       - name: Create a status check for the code coverage results
         id: dotnet-coverage-check
         # You may also reference just the major or major.minor version
-        uses: im-open/process-code-coverage-summary@v2.3.0
+        uses: im-open/process-code-coverage-summary@v2.3.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}     
           summary-file: './coverage-results/dotnet-summary.md'
@@ -166,7 +166,7 @@ jobs:
 
       - name: create status check/comment for code coverage results
         id: jest_coverage_check
-        uses: im-open/process-code-coverage-summary@v2.3.0
+        uses: im-open/process-code-coverage-summary@v2.3.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           summary-file: './coverage-results/jest-summary.md'

--- a/action.yml
+++ b/action.yml
@@ -76,5 +76,5 @@ outputs:
     description: 'The ID of the PR comment that was created.  This is only set if `create-pr-comment` is `true` and a PR was created successfully.'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
# Summary of PR changes

Updated the GitHub Action to use Node.js 24 runtime instead of Node.js 20.

https://im-jira.internal.towerswatson.com/browse/DEVO-1052

## Changes Made
- Updated `action.yml` to use `node24` runtime (changed from `node20`)

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
  - **Note:** This change should include `+semver:major` or `+semver:breaking` in a commit message as upgrading the Node runtime is a breaking change.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*

## Additional Notes
- The action needs to be recompiled by running `npm run build` before merging this PR.